### PR TITLE
Fix issues with node 0.6/npm 1.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
                   }
 , "dependencies": {  "underscore": "1.1.7"
     , "sprintf": "0.1.1"
-    , "ax": ">= 0.1.0"
+    , "ax": "https://github.com/andyburke/ax/tarball/master"
     , "cookiejar": "1.3.x"
   }
 , "devDependencies": { "vows": "0.5.11"


### PR DESCRIPTION
npm 1.0.x does not respect the 'files' keyword in package.json, resulting in an incomplete install.  This switches to the recognized 'directories' keyword.
