### PR TITLE
Fixed broken cookie functionality

### DIFF
--- a/lib/shred/response.js
+++ b/lib/shred/response.js
@@ -48,7 +48,7 @@ var Response = function(raw, request, callback) {
       }
 
       try {
-        cookie = new Cookie(cookieStr);
+        cookie = new Cookie(cookieString);
         if (cookie) {
           cookieObjs.push(cookie);
         }
@@ -57,7 +57,7 @@ var Response = function(raw, request, callback) {
       }
     }
 
-    request.cookieJar.setCookies(cookies);
+    request.cookieJar.setCookies(cookieObjs);
   }
 
   this.request = request;


### PR DESCRIPTION
A couple variables weren't renamed properly in a previous commit.
