### PR TITLE
Paramters in url for get request

### DIFF
--- a/lib/shred/request.js
+++ b/lib/shred/request.js
@@ -269,7 +269,7 @@ var processOptions = function(request,options) {
   }
 
   // Set the remaining options.
-  request.query = options.query||options.parameters;
+  request.query = options.query||options.parameters||request.query ;
   request.method = options.method;
   request.setHeader("user-agent",options.agent||"Shred for Node.js, Version 0.5.0");
   request.setHeaders(options.headers);


### PR DESCRIPTION
Example:

shred.get({
                url:"http://localhost/test?param=1",
})
"param=1" will be ignored.
This commit leave original request.query after url parse, if options.query or options.params not defined
