### PR TITLE
add support for post application/x-www-form-urlencoded parameters

### DIFF
--- a/lib/shred/content.js
+++ b/lib/shred/content.js
@@ -172,6 +172,12 @@ Content.registerProcessor(
     stringify: function(data) {
       return JSON.stringify(data); }});
 
+var qs = require('querystring');
+// Register the post processor, which is used for JSON-based media types.
+Content.registerProcessor(
+  ["application/x-www-form-urlencoded"],
+  { parser : qs.parse, stringify : qs.stringify });
+
 // Error functions are defined separately here in an attempt to make the code
 // easier to read.
 var Errors = {


### PR DESCRIPTION
var req = shred.post({
  url : "http://iread.wo.com.cn/pages/login.action",
  headers : headers,
  content : {
    phoneNum : 15620009233,
    password : "32746805",
    preLoginUrl : ''
  },
  on :
