### PR TITLE
Add an option to ignore certificate errors

### DIFF
--- a/lib/shred/request.js
+++ b/lib/shred/request.js
@@ -233,6 +233,20 @@ Object.defineProperties(Request.prototype, {
       return this;
     },
     enumerable: true
+  },
+
+// - **sslStrict***. Used to disable to auth check for ssl certificataes,
+//   set to true to use self signed certs
+
+  sslStrict: {
+    get: function() { return this._sslStrict; },
+    set: function(sslStrict) {
+      if(typeof(sslStrict) !== 'boolean')
+        return this;
+      this._sslStrict = sslStrict;
+      return this;
+    },
+    enumerable: true
   }
 });
 
@@ -360,6 +374,10 @@ var processOptions = function(request,options) {
   }
   request.timeout = options.timeout;
 
+  request.sslStrict = true;
+  if(typeof(options.sslStrict) !== undefined){
+    request.sslStrict = options.sslStrict;
+  }
 };
 
 // `createRequest` is also called by the constructor, after `processOptions`.
@@ -378,6 +396,7 @@ var createRequest = function(request) {
     method: request.method,
     path: request.path + (request.query ? '?'+request.query : ""),
     headers: request.getHeaders(),
+    rejectUnauthorized: request._sslStrict,
     // Node's HTTP/S modules will ignore this, but we are using the
     // browserify-http module in the browser for both HTTP and HTTPS, and this
     // is how you differentiate the two.


### PR DESCRIPTION
I needed an option to fetch stuff from a https server with self signed certificates so I added one.
sslStrict defaults to true which means that no self signed certs are allowed, setting it to false will make those work.

I wanted to run the test suite however some tests seem to be broken (already before I made my changes)
